### PR TITLE
Resource improvements

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,0 @@
-default['chef_backend']['admin'] = 'workflow'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,1 @@
+default['chef_backend']['admin'] = 'workflow'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -44,7 +44,7 @@ def write_vault(data)
     'chef_stack',
     node.chef_environment,
     node_name: node['chef_stack']['admin'],
-    client_key_path: '/etc/opscode/users/workflow.pem'
+    client_key_path: '/etc/chef/workflow.pem'
   )
   item.raw_data ||= { 'id' => node.chef_environment }
   item.raw_data.merge!(data)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -30,3 +30,20 @@ def ensurekv(config, hash)
   end
   config
 end
+
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/MethodLength
+def write_vault(data)
+  item = read_vault || ChefVault::Item.new(
+    'chef',
+    node.chef_environment,
+    node_name: 'workflow',
+    client_key_path: '/etc/opscode/users/workflow.pem'
+  )
+  item.raw_data ||= { 'id' => node.chef_environment }
+  item.raw_data.merge!(data)
+  item.search("chef_environment:#{node.chef_environment} AND recipe:chef")
+  item.clients("chef_environment:#{node.chef_environment} AND recipe:chef")
+  item.admins('workflow')
+  item.save
+end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -30,26 +30,3 @@ def ensurekv(config, hash)
   end
   config
 end
-
-# rubocop:disable Metrics/AbcSize
-# rubocop:disable Metrics/MethodLength
-def read_vault()
-  ChefVault::Item.load('chef_stack', node.chef_environment)
-end
-
-# rubocop:disable Metrics/AbcSize
-# rubocop:disable Metrics/MethodLength
-def write_vault(data)
-  item = read_vault || ChefVault::Item.new(
-    'chef_stack',
-    node.chef_environment,
-    node_name: node['chef_stack']['admin'],
-    client_key_path: '/etc/chef/#{node["chef_stack"]["admin"]}.pem'
-  )
-  item.raw_data ||= { 'id' => node.chef_environment }
-  item.raw_data.merge!(data)
-  item.search("chef_environment:#{node.chef_environment} AND recipe:chef_backend")
-  item.clients("chef_environment:#{node.chef_environment} AND recipe:chef_backend")
-  item.admins(node['chef_stack']['admin'])
-  item.save
-end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -35,15 +35,15 @@ end
 # rubocop:disable Metrics/MethodLength
 def write_vault(data)
   item = read_vault || ChefVault::Item.new(
-    'chef',
+    'chef_stack',
     node.chef_environment,
     node_name: 'workflow',
     client_key_path: '/etc/opscode/users/workflow.pem'
   )
   item.raw_data ||= { 'id' => node.chef_environment }
   item.raw_data.merge!(data)
-  item.search("chef_environment:#{node.chef_environment} AND recipe:chef")
-  item.clients("chef_environment:#{node.chef_environment} AND recipe:chef")
-  item.admins('workflow')
+  item.search("chef_environment:#{node.chef_environment} AND recipe:chef_backend")
+  item.clients("chef_environment:#{node.chef_environment} AND recipe:chef_backend")
+  item.admins(node['chef_stack']['admin'])
   item.save
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -33,6 +33,12 @@ end
 
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/MethodLength
+def read_vault()
+  ChefVault::Item.load('chef_stack', node.chef_environment)
+end
+
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/MethodLength
 def write_vault(data)
   item = read_vault || ChefVault::Item.new(
     'chef_stack',

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -37,7 +37,7 @@ def write_vault(data)
   item = read_vault || ChefVault::Item.new(
     'chef_stack',
     node.chef_environment,
-    node_name: 'workflow',
+    node_name: node['chef_stack']['admin'],
     client_key_path: '/etc/opscode/users/workflow.pem'
   )
   item.raw_data ||= { 'id' => node.chef_environment }

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -44,7 +44,7 @@ def write_vault(data)
     'chef_stack',
     node.chef_environment,
     node_name: node['chef_stack']['admin'],
-    client_key_path: '/etc/chef/workflow.pem'
+    client_key_path: '/etc/chef/#{node["chef_stack"]["admin"]}.pem'
   )
   item.raw_data ||= { 'id' => node.chef_environment }
   item.raw_data.merge!(data)

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,6 +7,6 @@ description 'Resource Cookbook for Managing Chef Software Inc Product Suite'
 long_description 'Resource Cookbook for Managing Chef Software Inc Product Suite'
 issues_url 'https://github.com/ncerny/chef_stack/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/ncerny/chef_stack' if respond_to?(:source_url)
-version '0.5.2'
+version '0.6.0'
 
 depends 'chef-ingredient'

--- a/resources/automate.rb
+++ b/resources/automate.rb
@@ -56,7 +56,7 @@ action :create do
     version new_resource.version
     config new_resource.config
     accept_license new_resource.accept_license
-    package_source new_resource.package_source if new_resource.property_is_set?(:package_source)
+    package_source new_resource.package_source if property_is_set?(:package_source)
   end
 
   directory '/etc/delivery'

--- a/resources/automate.rb
+++ b/resources/automate.rb
@@ -31,6 +31,7 @@ property :chef_user, String, default: 'workflow'
 property :chef_user_pem, String, required: true
 property :validation_pem, String, required: true
 property :builder_pem, String, required: true
+property :package_source, String
 
 load_current_value do
   # node.run_state['chef-users'] ||= Mixlib::ShellOut.new('chef-server-ctl user-list').run_command.stdout
@@ -55,6 +56,7 @@ action :create do
     version new_resource.version
     config new_resource.config
     accept_license new_resource.accept_license
+    package_source new_resource.package_source if new_resource.property_is_set?(:package_source)
   end
 
   directory '/etc/delivery'

--- a/resources/automate.rb
+++ b/resources/automate.rb
@@ -31,7 +31,6 @@ property :chef_user, String, default: 'workflow'
 property :chef_user_pem, String, required: true
 property :validation_pem, String, required: true
 property :builder_pem, String, required: true
-property :package_source, String
 
 load_current_value do
   # node.run_state['chef-users'] ||= Mixlib::ShellOut.new('chef-server-ctl user-list').run_command.stdout
@@ -56,7 +55,6 @@ action :create do
     version new_resource.version
     config new_resource.config
     accept_license new_resource.accept_license
-    package_source new_resource.package_source if property_is_set?(:package_source)
   end
 
   directory '/etc/delivery'

--- a/resources/automate.rb
+++ b/resources/automate.rb
@@ -109,6 +109,7 @@ action :create do
       execute "create enterprise #{ent}" do
         command "delivery-ctl create-enterprise #{ent} --ssh-pub-key-file=/etc/delivery/builder_key.pub > /etc/delivery/#{ent}.creds"
         not_if "delivery-ctl list-enterprises --ssh-pub-key-file=/etc/delivery/builder_key.pub | grep -w #{ent}"
+        only_if 'delivery-ctl status'
       end
     end
   end

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -66,6 +66,7 @@ action :create do
 
   execute "chef-backend-ctl join-cluster #{new_resource.bootstrap_node} --accept-license --yes" do
     not_if { node['fqdn'].eql?(new_resource.bootstrap_node) }
+    not_if 'chef-backend-ctl cluster-status'
   end
 end
 

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -1,4 +1,4 @@
-#
+
 # Cookbook Name:: chef_stack
 # Resource:: backend
 #
@@ -27,7 +27,7 @@ property :config, String, default: ''
 property :accept_license, [TrueClass, FalseClass], default: false
 property :bootstrap_node, String, required: true
 property :publish_address, String, default: node['ipaddress']
-property :chef_backend_secrets, String, default: nil
+property :chef_backend_secrets, String, default: ''
 
 load_current_value do
   # node.run_state['chef-users'] ||= Mixlib::ShellOut.new('chef-server-ctl user-list').run_command.stdout

--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -27,7 +27,7 @@ property :config, String, default: ''
 property :accept_license, [TrueClass, FalseClass], default: false
 property :bootstrap_node, String, required: true
 property :publish_address, String, default: node['ipaddress']
-property :chef_backend_secrets, String, default: ''
+property :chef_backend_secrets, String, default: nil
 
 load_current_value do
   # node.run_state['chef-users'] ||= Mixlib::ShellOut.new('chef-server-ctl user-list').run_command.stdout
@@ -56,6 +56,7 @@ action :create do
     group 'root'
     mode '0600'
     not_if { node['fqdn'].eql?(new_resource.bootstrap_node) }
+    only_if { new_resource.chef_backend_secrets }
   end
 
   execute 'chef-backend-ctl create-cluster --accept-license --yes' do

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -96,20 +96,3 @@ action :gather_secrets do
     action :run
   end
 end
-
-# rubocop:disable Metrics/AbcSize
-# rubocop:disable Metrics/MethodLength
-def write_vault(data)
-  item = read_vault || ChefVault::Item.new(
-    'chef',
-    node.chef_environment,
-    node_name: 'workflow',
-    client_key_path: '/etc/opscode/users/workflow.pem'
-  )
-  item.raw_data ||= { 'id' => node.chef_environment }
-  item.raw_data.merge!(data)
-  item.search("chef_environment:#{node.chef_environment} AND recipe:chef")
-  item.clients("chef_environment:#{node.chef_environment} AND recipe:chef")
-  item.admins('workflow')
-  item.save
-end

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -69,12 +69,12 @@ end
 action :gather_secrets do
   ruby_block 'gather chef-server secrets' do
     block do
-      chefserver = {}
+      chef_server = {}
       files = Dir.glob('/etc/opscode*/*.{rb,pem,pub,json}')
       files.each do |file|
-        chefserver[file] = IO.read(file)
+        chef_server[file] = IO.read(file)
       end
-      write_vault('chefserver' => chefserver)
+      write_vault('chef_server' => chef_server)
     end
     action :run
   end

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -65,34 +65,3 @@ action :create do
     end
   end
 end
-
-action :gather_secrets do
-  ruby_block 'gather chef-server secrets' do
-    block do
-      chef_server = {}
-      files = Dir.glob('/etc/opscode*/*.{rb,pem,pub,json}')
-      files.each do |file|
-        chef_server[file] = IO.read(file)
-      end
-      write_vault('chef_server' => chef_server)
-    end
-    action :run
-  end
-
-  ruby_block 'gather automate secrets' do
-    block do
-      supermarket_ocid = JSON.parse(::File.read('/etc/opscode/oc-id-applications/supermarket.json'))
-      automate = {
-        'validator_pem' => ::File.read('/etc/opscode/infrastructure-validation.pem'),
-        'user_pem' => ::File.read('/etc/opscode/users/workflow.pem'),
-        'builder_pem' => ::File.read('/etc/opscode/users/builder.pem'),
-        #  'builder_pub' => "ssh-rsa #{[builder_key.to_blob].pack('m0')}",
-        'supermarket_oauth2_app_id' => supermarket_ocid['uid'],
-        'supermarket_oauth2_secret' => supermarket_ocid['secret'],
-        'supermarket_fqdn' => URI(supermarket_ocid['redirect_uri']).host
-      }
-      write_vault('automate' => automate)
-    end
-    action :run
-  end
-end

--- a/resources/wf_builder.rb
+++ b/resources/wf_builder.rb
@@ -156,7 +156,7 @@ action :create do
   case new_resource.job_dispatch_version
   when 'v1'
     execute 'tag node as legacy build-node' do
-      command "knife tag create #{node['fqdn']} delivery-build-node -c new_resource.chef_config_path"
+      command "knife tag create #{Chef::Config['node_name']} delivery-build-node -c new_resource.chef_config_path"
       not_if { node['tags'].include?('delivery-build-node') }
     end
 
@@ -200,7 +200,7 @@ action :create do
     home_dir = '/home/job_runner'
 
     execute 'tag node as job-runner' do
-      command "knife tag create #{node['fqdn']} delivery-job-runner -c #{new_resource.chef_config_path}"
+      command "knife tag create #{Chef::Config['node_name']} delivery-job-runner -c #{new_resource.chef_config_path}"
       not_if { node['tags'].include?('delivery-job-runner') }
     end
 

--- a/resources/wf_builder.rb
+++ b/resources/wf_builder.rb
@@ -69,10 +69,11 @@ action :create do
 
   execute 'cat /etc/chef/trusted_certs/*.crt >> /opt/chefdk/embedded/ssl/certs/cacert.pem'
 
-  #ohai 'reload_passwd' do
-  #  action :nothing
-  #  plugin 'etc'
-  #end
+  ohai 'reload_passwd' do
+    action :nothing
+    plugin 'etc'
+    ignore_failure true
+  end
 
   workspace = '/var/opt/delivery/workspace'
 
@@ -81,7 +82,7 @@ action :create do
   user 'dbuild' do
     home workspace
     group 'dbuild'
-    #notifies :reload, 'ohai[reload_passwd]', :immediately
+    notifies :reload, 'ohai[reload_passwd]', :immediately
   end
 
   %w(.chef bin lib etc).each do |dir|

--- a/resources/wf_builder.rb
+++ b/resources/wf_builder.rb
@@ -116,8 +116,7 @@ action :create do
                        node_name: new_resource.chef_user,
                        log_location: 'STDOUT',
                        client_key: "#{workspace}/#{dir}/#{new_resource.chef_user}.pem",
-                       trusted_certs_dir: '/etc/chef/trusted_certs'
-                      )
+                       trusted_certs_dir: '/etc/chef/trusted_certs')
       mode '0644'
       owner 'dbuild'
       group 'dbuild'

--- a/resources/wf_builder.rb
+++ b/resources/wf_builder.rb
@@ -69,10 +69,10 @@ action :create do
 
   execute 'cat /etc/chef/trusted_certs/*.crt >> /opt/chefdk/embedded/ssl/certs/cacert.pem'
 
-  ohai 'reload_passwd' do
-    action :nothing
-    plugin 'etc'
-  end
+  #ohai 'reload_passwd' do
+  #  action :nothing
+  #  plugin 'etc'
+  #end
 
   workspace = '/var/opt/delivery/workspace'
 
@@ -81,7 +81,7 @@ action :create do
   user 'dbuild' do
     home workspace
     group 'dbuild'
-    notifies :reload, 'ohai[reload_passwd]', :immediately
+    #notifies :reload, 'ohai[reload_passwd]', :immediately
   end
 
   %w(.chef bin lib etc).each do |dir|
@@ -156,7 +156,7 @@ action :create do
   case new_resource.job_dispatch_version
   when 'v1'
     execute 'tag node as legacy build-node' do
-      command "knife tag create #{node['fqdn']} delivery-build-node -c new_resource.chef_config_path -u #{node['fqdn']}"
+      command "knife tag create #{node['fqdn']} delivery-build-node -c new_resource.chef_config_path"
       not_if { node['tags'].include?('delivery-build-node') }
     end
 
@@ -200,7 +200,7 @@ action :create do
     home_dir = '/home/job_runner'
 
     execute 'tag node as job-runner' do
-      command "knife tag create #{node['fqdn']} delivery-job-runner -c #{new_resource.chef_config_path} -u #{node['fqdn']}"
+      command "knife tag create #{node['fqdn']} delivery-job-runner -c #{new_resource.chef_config_path}"
       not_if { node['tags'].include?('delivery-job-runner') }
     end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 require 'spec_helper'
 
 describe 'chef_stack::default' do


### PR DESCRIPTION
- Added guards to several resource actions.
- Changed order of operations for backend resource, so you could provide a chef_backend_secrets before creating a cluster, if desired.
- Replaced some hardcoded references to `/etc/chef/client.rb` with a property that defaults to that value.
- Replaced some references of `node['fqdn']` with `Chef::Config['node_name'] ` to support use cases where the node_name is not the fqdn. This builds on the cookbook's assumption that all these nodes are also clients (of chef-solo/zero or another chef server).