### PR TITLE
fixing 'source is required' error

### DIFF
--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -50,13 +50,14 @@ action :create do
     content new_resource.config
   end
 
-  chef_file '/etc/chef-backend/chef-backend-secrets.json' do
-    source new_resource.chef_backend_secrets
-    user 'root'
-    group 'root'
-    mode '0600'
-    not_if { node['fqdn'].eql?(new_resource.bootstrap_node) }
-    only_if { new_resource.chef_backend_secrets }
+  if new_resource.chef_backend_secrets
+    chef_file '/etc/chef-backend/chef-backend-secrets.json' do
+      source new_resource.chef_backend_secrets
+      user 'root'
+      group 'root'
+      mode '0600'
+      not_if { node['fqdn'].eql?(new_resource.bootstrap_node) }
+    end
   end
 
   execute 'chef-backend-ctl create-cluster --accept-license --yes' do


### PR DESCRIPTION
This fixes:
```
Chef::Exceptions::ValidationFailed
ec2-52-32-21-76.us-west-2.compute.amazonaws.com     ----------------------------------
ec2-52-32-21-76.us-west-2.compute.amazonaws.com     source is required
ec2-52-32-21-76.us-west-2.compute.amazonaws.com
ec2-52-32-21-76.us-west-2.compute.amazonaws.com     Cookbook Trace:
ec2-52-32-21-76.us-west-2.compute.amazonaws.com     ---------------
ec2-52-32-21-76.us-west-2.compute.amazonaws.com     /var/chef/cache/cookbooks/chef_stack/resources/backend.rb:54:in `block (2 levels) in class_from_file'
ec2-52-32-21-76.us-west-2.compute.amazonaws.com     /var/chef/cache/cookbooks/chef_stack/resources/backend.rb:53:in `block in class_from_file'
```
Signed-off-by: Jeremy J. Miller <jm@chef.io>