### PR TITLE
Remove default value of `nil`

### DIFF
--- a/resources/backend.rb
+++ b/resources/backend.rb
@@ -27,7 +27,7 @@ property :config, String, default: ''
 property :accept_license, [TrueClass, FalseClass], default: false
 property :bootstrap_node, String, required: true
 property :publish_address, String, default: node['ipaddress']
-property :chef_backend_secrets, String, default: nil
+property :chef_backend_secrets, String
 property :platform, String
 property :platform_version, String
 
@@ -54,7 +54,7 @@ action :create do
     content new_resource.config
   end
 
-  if new_resource.chef_backend_secrets
+  if new_resource.property_is_set?(:chef_backend_secrets)
     chef_file '/etc/chef-backend/chef-backend-secrets.json' do
       source new_resource.chef_backend_secrets
       user 'root'


### PR DESCRIPTION
The chef_backend_secrets property accepts a String object but defines a default value of nil. This change removes the default value, and uses :property_is_set? method to validate value

This fixes the deprecation warning seen when using the `chef_server` resource.

```text
Deprecated features used!
         Default value nil is invalid for property chef_backend_secrets of resource chef_backend. Possible fixes: 1. Remove 'default: nil' if nil means 'undefined'. 2. Set a valid default value if there is a reasonable one. 3. Allow nil as a valid value of your property (for example, 'property :chef_backend_secrets, [ String, nil ], default: nil'). Error: Property chef_backend_secrets must be one of: String!  You passed nil. at 1 location:
           - /tmp/kitchen/cache/cookbooks/chef_stack/resources/backend.rb:30:in `class_from_file'
          See https://docs.chef.io/deprecations_custom_resource_cleanups.html for further details.
```