### PR TITLE
Supply bogus string value to statisfy resource

### DIFF
--- a/resources/client.rb
+++ b/resources/client.rb
@@ -111,7 +111,7 @@ action :install do
   end
 
   chef_file ::File.join(prefix, 'validation.pem') do
-    source new_resource.validation_pem
+    source new_resource.validation_pem || 'null_value'
     user 'root'
     group 'root'
     mode '0600'


### PR DESCRIPTION
When the chef_client resource is run with no value for the
validation_pem attribute, it rasies an error. This provides
the source attribute for the nested `chef_file` resource so
that it will compile and then the resource guards prevent
still properly prevent execution.

Fixes #27