### PR TITLE
Fix regex to determine if source is a URI

### DIFF
--- a/resources/file.rb
+++ b/resources/file.rb
@@ -42,7 +42,7 @@ action :create do
       group new_resource.group
       mode new_resource.mode
     end
-  elsif new_resource.source =~ %r{[a-zA-Z]*://.*}
+  elsif new_resource.source =~ %r{^[a-zA-Z]*://.*}
     remote_file new_resource.filename do
       source new_resource.source
       user new_resource.user


### PR DESCRIPTION
The current regex will match against a valid URI scheme anywhere in the
configuration string. This change limits the check to strings that begin with a
URI-like scheme definition